### PR TITLE
debug: log HTML preview and CSS classes in parseBooksMarkup

### DIFF
--- a/Sources/KindleAPI/KindleAPI.swift
+++ b/Sources/KindleAPI/KindleAPI.swift
@@ -204,9 +204,21 @@ extension KindleAPI {
 
     /// Parse a string http request response markup into an array of Books and the next page token
     private func parseBooksMarkup(_ responseBody: String) throws -> ([KindleHTMLBook], String?) {
+        // Log the first 2000 chars of the HTML response to help debug selector changes.
+        // This is intentionally verbose — remove once Amazon's new markup is understood.
+        let preview = String(responseBody.prefix(2000))
+        logger?.debug("parseBooksMarkup HTML preview (first 2000 chars):\n\(preview)")
+
         let page = try SwiftSoup.parse(responseBody)
+
+        // Log all top-level class names to help identify new selectors if the old one stops working.
+        let allClasses = (try? page.select("[class]").array().compactMap { try? $0.attr("class") }) ?? []
+        let uniqueClasses = Array(Set(allClasses.flatMap { $0.split(separator: " ").map(String.init) })).sorted()
+        logger?.debug("parseBooksMarkup: found \(uniqueClasses.count) unique CSS classes in response: \(uniqueClasses.joined(separator: ", "))")
+
         let booksMarkup = try page.select(".kp-notebook-library-each-book")
         guard !booksMarkup.isEmpty() else {
+            logger?.error("parseBooksMarkup: selector '.kp-notebook-library-each-book' matched 0 elements. Amazon may have changed the markup. See HTML preview above.")
             throw KindleError.htmlDecodingError(nil)
         }
 


### PR DESCRIPTION
## What & Why

Amazon changed the HTML structure of `read.amazon.com/notebook`. The selector `.kp-notebook-library-each-book` matches nothing, so `parseBooksMarkup` throws `htmlDecodingError(nil)` immediately after a successful login.

This PR adds temporary debug logging to help identify the new selectors:

1. **First 2000 chars of the raw HTML response** — lets us see what Amazon is actually returning
2. **All unique CSS class names in the page** — lets us spot the new book container class name quickly
3. **Explicit error log** when the selector fails — clearer than a silent nil error

## How to use

Run the app, log in, then capture logs:
```bash
xcrun simctl spawn booted log stream \
  --predicate 'subsystem == "io.respawn.Scrapes"' \
  --level debug
```

Share the output and we can identify the new selectors, fix `parseBooksMarkup` and `KindleHTMLBook`, and add tests.

## Cleanup

These logs should be removed once the correct selectors are identified and the parser is fixed.

🤖 Generated with Claude Code