### PR TITLE
fix(task-17): harden HTML book parsing + diagnose Amazon markup changes

### DIFF
--- a/Sources/KindleAPI/KindleAPI.swift
+++ b/Sources/KindleAPI/KindleAPI.swift
@@ -202,23 +202,60 @@ extension KindleAPI {
         }
     }
 
-    /// Parse a string http request response markup into an array of Books and the next page token
+    /// Parse a string http request response markup into an array of Books and the next page token.
+    ///
+    /// ## Amazon Notebook HTML Structure (as of late 2024)
+    ///
+    /// Books are rendered in server-side HTML at `read.amazon.com/notebook?library=list&token=<token>`.
+    /// Each book is a `<div id="<ASIN>" class="kp-notebook-library-each-book ...">` containing:
+    /// - `<h2>` or `<h2 class="kp-notebook-searchable">` — book title
+    /// - `<p class="kp-notebook-searchable">` — author, prefixed with "By: "
+    /// - `<img class="kp-notebook-cover-image">` — cover image
+    /// - `<input id="kp-notebook-annotated-date-<ASIN>" type="hidden" value="<date>">` — last annotation date
+    /// - Pagination token in `<input class="kp-notebook-library-next-page-start" value="<token>">`
+    ///
+    /// ## Debugging selector changes
+    ///
+    /// If Amazon changes the HTML structure and this method fails, enable debug logging and check:
+    /// 1. The HTML preview logged below (first 500 chars) — tells you if server-side rendering is still active
+    /// 2. All unique CSS classes logged below — spot the new book container class
+    /// 3. If the page looks like a JavaScript app shell (no `kp-notebook-*` classes), Amazon may have
+    ///    moved to a fully client-side-rendered (React/SPA) approach. In that case, plain URLSession
+    ///    requests can no longer fetch the book list — a WKWebView-based solution would be required.
+    ///
     private func parseBooksMarkup(_ responseBody: String) throws -> ([KindleHTMLBook], String?) {
-        // Log the first 2000 chars of the HTML response to help debug selector changes.
-        // This is intentionally verbose — remove once Amazon's new markup is understood.
-        let preview = String(responseBody.prefix(2000))
-        logger?.debug("parseBooksMarkup HTML preview (first 2000 chars):\n\(preview)")
+        // Log a short HTML preview and all CSS class names to aid debugging when Amazon changes markup.
+        // These logs are only visible when a logger is configured with debug level enabled.
+        let preview = String(responseBody.prefix(500))
+        logger?.debug("parseBooksMarkup: HTML preview (first 500 chars):\n\(preview)")
 
         let page = try SwiftSoup.parse(responseBody)
+        let pageTitle = (try? page.title()) ?? "(unknown)"
+        logger?.debug("parseBooksMarkup: page title = \"\(pageTitle)\"")
 
-        // Log all top-level class names to help identify new selectors if the old one stops working.
         let allClasses = (try? page.select("[class]").array().compactMap { try? $0.attr("class") }) ?? []
         let uniqueClasses = Array(Set(allClasses.flatMap { $0.split(separator: " ").map(String.init) })).sorted()
-        logger?.debug("parseBooksMarkup: found \(uniqueClasses.count) unique CSS classes in response: \(uniqueClasses.joined(separator: ", "))")
+        let kpClasses = uniqueClasses.filter { $0.hasPrefix("kp-notebook") }
+        logger?.debug("parseBooksMarkup: \(kpClasses.count) kp-notebook-* classes found: \(kpClasses.joined(separator: ", "))")
 
         let booksMarkup = try page.select(".kp-notebook-library-each-book")
         guard !booksMarkup.isEmpty() else {
-            logger?.error("parseBooksMarkup: selector '.kp-notebook-library-each-book' matched 0 elements. Amazon may have changed the markup. See HTML preview above.")
+            // Detect whether this looks like a JavaScript app shell (no kp-notebook classes at all),
+            // which would mean Amazon migrated the page to client-side rendering.
+            if kpClasses.isEmpty {
+                logger?.error(
+                    "parseBooksMarkup: no kp-notebook-* CSS classes found in the response. "
+                    + "Amazon may have migrated read.amazon.com/notebook to a client-side-rendered "
+                    + "(React/SPA) page. Plain URLSession requests will not work — a WKWebView-based "
+                    + "approach may be required. HTML preview: \(preview)"
+                )
+            } else {
+                logger?.error(
+                    "parseBooksMarkup: selector '.kp-notebook-library-each-book' matched 0 elements, "
+                    + "but kp-notebook-* classes are present (\(kpClasses.joined(separator: ", "))). "
+                    + "Amazon likely changed the book container class. HTML preview: \(preview)"
+                )
+            }
             throw KindleError.htmlDecodingError(nil)
         }
 

--- a/Sources/KindleAPI/KindleAPI.swift
+++ b/Sources/KindleAPI/KindleAPI.swift
@@ -204,9 +204,21 @@ extension KindleAPI {
 
     /// Parse a string http request response markup into an array of Books and the next page token
     private func parseBooksMarkup(_ responseBody: String) throws -> ([KindleHTMLBook], String?) {
+        // Log the first 2000 chars of the HTML response to help debug selector changes.
+        // This is intentionally verbose — remove once Amazon's new markup is understood.
+        let preview = String(responseBody.prefix(2000))
+        logger?.debug("parseBooksMarkup HTML preview (first 2000 chars):\n\(preview)")
+
         let page = try SwiftSoup.parse(responseBody)
+
+        // Log all top-level class names to help identify new selectors if the old one stops working.
+        let allClasses = (try? page.select("[class]").array().compactMap { try? $0.attr("class") }) ?? []
+        let uniqueClasses = Array(Set(allClasses.flatMap { $0.split(separator: " ").map(String.init) })).sorted()
+        logger?.debug("parseBooksMarkup: found \(uniqueClasses.count) unique CSS classes in response: \(uniqueClasses.joined(separator: ", "))")
+
         let booksMarkup = try page.select(".kp-notebook-library-each-book")
         guard !booksMarkup.isEmpty() else {
+            logger?.error("parseBooksMarkup: selector '.kp-notebook-library-each-book' matched 0 elements. Amazon may have changed the markup. See HTML preview above.")
             throw KindleError.htmlDecodingError(nil)
         }
 

--- a/Sources/KindleAPI/KindleEndpoint.swift
+++ b/Sources/KindleAPI/KindleEndpoint.swift
@@ -16,12 +16,17 @@ public struct KindleEndpoint: Sendable {
         return URL(string: urlString)!
     }
 
-    /// Represents Kindle Web Reader login page (via Amazon).
-    /// TODO This should be unpacked into the base URL And a bunch of parameters that are easier to read.
+    /// Represents the Amazon OpenID login page that returns to the Kindle Notebook after sign-in.
+    ///
+    /// Previously this pointed to `read.amazon.com/kindle-library`, but Amazon discontinued the
+    /// Kindle Cloud Reader library page (it now redirects to `/kindle-library/not-supported`).
+    /// The login now targets `read.amazon.com/notebook` instead, which is the Kindle Highlights &
+    /// Notebook page and remains supported. The `assoc_handle` parameter changed accordingly from
+    /// `amzn_kindle_mykindle_us` to `amzn_kindle_ynhv2_us`.
     ///
     public static let login = KindleEndpoint(
         urlString:
-            "https://www.amazon.com/ap/signin?openid.pape.max_auth_age=1209600&openid.return_to=https%3A%2F%2Fread.amazon.com%2Fkindle-library&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.assoc_handle=amzn_kindle_mykindle_us&openid.mode=checkid_setup&language=en_US&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&pageId=amzn_kindle_mykindle_us&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0"
+            "https://www.amazon.com/ap/signin?openid.pape.max_auth_age=3600&openid.return_to=https%3A%2F%2Fread.amazon.com%2Fnotebook&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.assoc_handle=amzn_kindle_ynhv2_us&openid.mode=checkid_setup&language=en_US&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&pageId=amzn_kindle_ynhv2_us&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0"
     )
 
     public static func deviceInfo(token: String) -> KindleEndpoint {
@@ -31,7 +36,18 @@ public struct KindleEndpoint: Sendable {
         )
     }
 
-    public static let library = KindleEndpoint(urlString: "https://read.amazon.com/kindle-library")
+    /// The Kindle Notebook & Highlights landing page.
+    ///
+    /// This is used as the post-login destination and as the trigger page for cookie extraction.
+    /// The old `read.amazon.com/kindle-library` URL is discontinued by Amazon (redirects to
+    /// `/kindle-library/not-supported`); the notebook page serves the same role.
+    ///
+    public static let notebook = KindleEndpoint(urlString: "https://read.amazon.com/notebook")
+
+    /// Deprecated. Amazon discontinued `read.amazon.com/kindle-library`.
+    /// Use ``notebook`` instead.
+    @available(*, deprecated, renamed: "notebook")
+    public static let library = KindleEndpoint(urlString: "https://read.amazon.com/notebook")
 
     /// Fetches book details in JSON format.
     /// Useful to grab metadataURL and YJVersion string

--- a/Sources/KindleAPI/Models/KindleHTMLBook.swift
+++ b/Sources/KindleAPI/Models/KindleHTMLBook.swift
@@ -22,12 +22,27 @@ public struct KindleHTMLBook {
     public let coverImageURL: URL
 
     /// Make a new `Book` from a `SwiftSoup.Element` and return it.
+    ///
+    /// ## Expected element structure (as of late 2024)
+    ///
+    /// ```html
+    /// <div id="<ASIN>" class="kp-notebook-library-each-book ...">
+    ///   <img class="kp-notebook-cover-image" src="https://..."/>
+    ///   <h2>Book Title</h2>                      <!-- or <h2 class="kp-notebook-searchable"> -->
+    ///   <p class="kp-notebook-searchable">By: Author Name</p>
+    ///   <input id="kp-notebook-annotated-date-<ASIN>" type="hidden" value="Wednesday Jan 1, 2025"/>
+    /// </div>
+    /// ```
+    ///
     public init(from markup: SwiftSoup.Element) throws {
 
         let id = markup.id()
         self.asin = id
 
-        let kindleTitle = try markup.select("h2").first()?.text()
+        // Try both the plain h2 and the class-qualified variant for robustness.
+        // Amazon has used both `<h2>` and `<h2 class="kp-notebook-searchable">` in different page versions.
+        let kindleTitle = try markup.select("h2.kp-notebook-searchable").first()?.text()
+            ?? markup.select("h2").first()?.text()
         guard let kindleTitle = kindleTitle else {
             throw KindleError.htmlDecodingError(nil)
         }

--- a/Tests/KindleAPITests/KindleAPITests.swift
+++ b/Tests/KindleAPITests/KindleAPITests.swift
@@ -201,6 +201,41 @@ struct KindleHTMLBookTests {
         let book = try KindleHTMLBook(from: element)
         #expect(book.author == "Author Name Without Prefix")
     }
+
+    // Amazon has used both plain <h2> and <h2 class="kp-notebook-searchable"> in different page versions.
+    // The parser should handle both.
+    @Test("parses title from h2.kp-notebook-searchable element")
+    func parsesTitleFromClassedH2() throws {
+        let html = """
+            <div id="B084357H23" class="kp-notebook-library-each-book">
+                <img class="kp-notebook-cover-image" src="https://m.media-amazon.com/images/I/cover.jpg"/>
+                <h2 class="kp-notebook-searchable">The Invisible Life of Addie LaRue</h2>
+                <p class="kp-notebook-searchable">By: Schwab, V. E.</p>
+                <input id="kp-notebook-annotated-date-B084357H23" type="hidden" value="Wednesday Jan 1, 2025"/>
+            </div>
+            """
+        let doc = try SwiftSoup.parse(html)
+        let element = try doc.select(".kp-notebook-library-each-book").first()!
+        let book = try KindleHTMLBook(from: element)
+        #expect(book.title == "The Invisible Life of Addie LaRue")
+    }
+
+    @Test("parses title from plain h2 when h2.kp-notebook-searchable is absent")
+    func parsesTitleFromPlainH2WhenClassedH2Absent() throws {
+        // Verifies the fallback: if <h2 class="kp-notebook-searchable"> is not found, fall back to <h2>.
+        let html = """
+            <div id="B084357H23" class="kp-notebook-library-each-book">
+                <img class="kp-notebook-cover-image" src="https://m.media-amazon.com/images/I/cover.jpg"/>
+                <h2>Plain H2 Title</h2>
+                <p class="kp-notebook-searchable">By: Author Name</p>
+                <input id="kp-notebook-annotated-date-B084357H23" type="hidden" value="Wednesday Jan 1, 2025"/>
+            </div>
+            """
+        let doc = try SwiftSoup.parse(html)
+        let element = try doc.select(".kp-notebook-library-each-book").first()!
+        let book = try KindleHTMLBook(from: element)
+        #expect(book.title == "Plain H2 Title")
+    }
 }
 
 // MARK: - KindleHTMLAnnotation Parsing Tests

--- a/Tests/KindleAPITests/KindleAPITests.swift
+++ b/Tests/KindleAPITests/KindleAPITests.swift
@@ -92,18 +92,23 @@ struct KindleEndpointTests {
         #expect(query.contains("deviceType=device-token-abc"))
     }
 
-    @Test("login URL points to Amazon sign-in")
+    @Test("login URL points to Amazon sign-in and returns to notebook")
     func loginURL() {
         let url = KindleEndpoint.login.url
         #expect(url.host() == "www.amazon.com")
         #expect(url.path() == "/ap/signin")
+        // After Amazon discontinued the Kindle Cloud Reader library page, the login
+        // flow must return to the notebook page instead of kindle-library.
+        let query = url.query() ?? ""
+        #expect(query.contains("notebook"))
+        #expect(!query.contains("kindle-library"))
     }
 
-    @Test("library URL points to Kindle library")
-    func libraryURL() {
-        let url = KindleEndpoint.library.url
+    @Test("notebook URL points to Kindle Notebook")
+    func notebookURL() {
+        let url = KindleEndpoint.notebook.url
         #expect(url.host() == "read.amazon.com")
-        #expect(url.path() == "/kindle-library")
+        #expect(url.path() == "/notebook")
     }
 }
 


### PR DESCRIPTION
## What & Why

Amazon changed the HTML structure of `read.amazon.com/notebook`, causing `parseBooksMarkup()` to throw `KindleError.htmlDecodingError(nil)` after a successful login. The selector `.kp-notebook-library-each-book` matches zero elements.

This PR consolidates all task-17 work into a single branch:

1. **Login URL fix** (cherry-picked from `task-17-fix-amazon-login`): Updates the Amazon OpenID login return URL from the discontinued `kindle-library` page to `notebook`, and updates the `assoc_handle` parameter accordingly.

2. **Debug logging improvement** (cherry-picked from `debug-log-html-response`): Logs first 2000 chars of HTML and all CSS classes — already open as PR #6, superseded by this PR.

3. **Improved diagnostics in parseBooksMarkup**: Smarter error messages that distinguish between:
   - **No `kp-notebook-*` classes at all** → Amazon likely migrated to a client-side-rendered (React/SPA) page; plain `URLSession` requests won't work; a `WKWebView`-based solution in the Scrapes app layer is needed.
   - **Some `kp-notebook-*` classes present, but container class changed** → Amazon changed the book container class name; the specific new class name will appear in the log.
   - Logs the page title, 500-char HTML preview, and all `kp-notebook-*` classes found.

4. **KindleHTMLBook title selector hardening**: Tries `h2.kp-notebook-searchable` first, falls back to plain `h2`. Amazon has used both in different page versions (the obsidian-kindle-plugin confirms `h2.kp-notebook-searchable` is the current form).

5. **Documentation**: Both `parseBooksMarkup` and `KindleHTMLBook.init(from:)` now document the expected HTML structure and how to debug selector changes.

## Investigation findings

- The obsidian-kindle-plugin (last updated Feb 2026) uses Electron's `BrowserWindow` to load the page with full JavaScript execution. They still use `.kp-notebook-library-each-book` — so the class likely still exists, but only after JavaScript renders the page.
- Plain `URLSession` requests (what KindleAPI uses) get only the server-side rendered shell. Amazon appears to have made the book list client-side rendered.
- The page does redirect to the correct login URL with `assoc_handle=amzn_kindle_ynhv2_us` — confirming the login URL fix is correct.

## How to capture diagnostic logs

Run the app, log in, then:
```bash
xcrun simctl spawn booted log stream \
  --predicate 'subsystem == "io.respawn.Scrapes"' \
  --level debug
```

Share the output — specifically the `parseBooksMarkup:` log lines — and we can determine whether to update the CSS selector or implement a WKWebView-based solution.

## Tests

62 tests pass (added 2 new tests for `h2.kp-notebook-searchable` and `h2` fallback behavior).

## Supersedes

This PR supersedes PR #6 (`debug-log-html-response`) — please close #6 when this is merged.

🤖 Generated with Claude Code