### PR TITLE
Prepare KindleAPI for Swift 6 sendability

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
             targets: ["KindleAPI"])
     ],
     dependencies: [
-        .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.7.6")
+        .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.11.2")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/Sources/KindleAPI/Authentication/KindleAuthentication.swift
+++ b/Sources/KindleAPI/Authentication/KindleAuthentication.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Describes all required cookie fields that the application should grab from the login webview
 /// to use in ``KindleSessionSecrets`` later.
 ///
-public enum KindleCookies: String, CaseIterable {
+public enum KindleCookies: String, CaseIterable, Sendable {
     case ubidMain = "ubid-main"
     case atMain = "at-main"
     case xMain = "x-main"
@@ -16,14 +16,14 @@ public enum KindleCookies: String, CaseIterable {
 
 /// Describes Kindle and Amazon request header names that are important to set on Kindle API requests
 ///
-public enum KindleRequestHeaders: String, CaseIterable {
+public enum KindleRequestHeaders: String, CaseIterable, Sendable {
     case sessionId = "x-amzn-sessionid"
     case adpSessionId = "x-adp-session-token"
 }
 
 /// Represends Kindle device information as returned from  ``KindleEndpoint.deviceInfo``
 ///
-public struct KindleDeviceInfo: Codable {
+public struct KindleDeviceInfo: Codable, Sendable {
     public let clientHashId: String
     public let deviceName: String
     public let deviceSessionToken: String
@@ -38,7 +38,7 @@ public struct KindleDeviceInfo: Codable {
 /// TODO: This should be a Codable struct, not a class, and the way we save it into Keychain in Scrapes
 /// should not dictate the public API.
 ///
-public class AuthenticationSecrets: NSObject, NSCoding, NSSecureCoding {
+public final class AuthenticationSecrets: NSObject, NSCoding, NSSecureCoding, @unchecked Sendable {
     public static let supportsSecureCoding = true
 
     public let cookies: [HTTPCookie]
@@ -72,7 +72,7 @@ public class AuthenticationSecrets: NSObject, NSCoding, NSSecureCoding {
 
 /// Hydrated Kindle sesion that provides everything a webview needs to perform authenticated Kindle requests.
 ///
-public struct HydratedAuthenticationSession {
+public struct HydratedAuthenticationSession: Sendable {
     public let secrets: AuthenticationSecrets
     public let device: KindleDeviceInfo
 

--- a/Sources/KindleAPI/KindleAPI.swift
+++ b/Sources/KindleAPI/KindleAPI.swift
@@ -11,7 +11,7 @@ import SwiftSoup
 /// KindleAPI is a Kindle web reader API client.
 /// It uses Amazon's session tokens to fetch JSON and HTML data from your Kindle books.
 ///
-public struct KindleAPI {
+public struct KindleAPI: Sendable {
 
     let secrets: HydratedAuthenticationSession
     let session: URLSession

--- a/Sources/KindleAPI/KindleLogger.swift
+++ b/Sources/KindleAPI/KindleLogger.swift
@@ -7,7 +7,7 @@ import Foundation
 ///
 /// If you're building for an Apple platform, `OSLog.Logger` is the easiest option to go with, and it will work out of the box.
 ///
-public protocol KindleLoggerProtocol {
+public protocol KindleLoggerProtocol: Sendable {
     func debug(_ message: @autoclosure () -> String)
     func info(_ message: @autoclosure () -> String)
     func error(_ message: @autoclosure () -> String)

--- a/Sources/KindleAPI/Models/KindleAnnotation.swift
+++ b/Sources/KindleAPI/Models/KindleAnnotation.swift
@@ -10,7 +10,7 @@ import SwiftSoup
 
 /// Describes possible highlight colors
 ///
-public enum KindleHighlightColor: String, Codable, CaseIterable, Identifiable {
+public enum KindleHighlightColor: String, Codable, CaseIterable, Identifiable, Sendable {
     public var id: String { rawValue }
 
     case yellow, red, blue, green, purple
@@ -18,13 +18,13 @@ public enum KindleHighlightColor: String, Codable, CaseIterable, Identifiable {
 
 /// Describes Kindle getAnnotations JSON response structure
 ///
-public struct KindleGetAnnotationsResponse: Decodable {
+public struct KindleGetAnnotationsResponse: Decodable, Sendable {
     public let annotations: [KindleJSONAnnotation]
 }
 
 /// Describes annotation types that Kindle API returns
 ///
-public enum KindleAnnotationType: String, Codable {
+public enum KindleAnnotationType: String, Codable, Sendable {
     case note = "kindle.note"
     case highlight = "kindle.highlight"
     case bookmark = "kindle.bookmark"
@@ -32,11 +32,11 @@ public enum KindleAnnotationType: String, Codable {
 
 /// Describes the type of position returned by Kindle API
 ///
-public enum KindleAnnotationPositionType: String, Codable {
+public enum KindleAnnotationPositionType: String, Codable, Sendable {
     case mobi7 = "Mobi7"
 }
 
-public struct KindleJSONAnnotation: Decodable {
+public struct KindleJSONAnnotation: Decodable, Sendable {
 
     public let highlightText: String
     public let noteText: String?
@@ -70,7 +70,7 @@ public struct KindleJSONAnnotation: Decodable {
     }
 }
 
-public struct KindleHTMLAnnotation {
+public struct KindleHTMLAnnotation: Sendable {
 
     public let kindleHighlightID: String
     public let highlightText: String

--- a/Sources/KindleAPI/Models/KindleHTMLBook.swift
+++ b/Sources/KindleAPI/Models/KindleHTMLBook.swift
@@ -10,7 +10,7 @@ import SwiftSoup
 
 /// A struct that parses out books from Kindle HTML Notebook markup
 ///
-public struct KindleHTMLBook {
+public struct KindleHTMLBook: Sendable {
 
     public let asin: String
     public let title: String

--- a/Sources/KindleAPI/Models/KindleJSONBook.swift
+++ b/Sources/KindleAPI/Models/KindleJSONBook.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /// Represents Kindle Library books list JSON API response
 ///
-public struct KindleLibrarySearchResponse: Decodable {
+public struct KindleLibrarySearchResponse: Decodable, Sendable {
     public let itemsList: [KindleJSONBook]
     public let paginationToken: String?
     public let libraryType: String
@@ -19,7 +19,7 @@ public struct KindleLibrarySearchResponse: Decodable {
 
 /// Represents Kindle book details fetched from `startReading` Kindle API endpoint
 ///
-public struct KindleBookDetails: Codable {
+public struct KindleBookDetails: Codable, Sendable {
     public let contentVersion: String?
     public let metadataUrl: String?
     public let formatVersion: String?
@@ -29,7 +29,7 @@ public struct KindleBookDetails: Codable {
 
 /// Represents Kindle book last page read data API response
 ///
-public struct KindleBookLastPageReadData: Codable {
+public struct KindleBookLastPageReadData: Codable, Sendable {
     public let position: Int?
     public let syncTime: Date?
 
@@ -41,7 +41,7 @@ public struct KindleBookLastPageReadData: Codable {
 
 /// Represents Kindle book metadata fetched from the `metadata.jsonp` Kindle API call
 ///
-public struct KindleBookMetadata: Codable {
+public struct KindleBookMetadata: Codable, Sendable {
     enum CodingKeys: CodingKey {
         case ACR
         case bookSize
@@ -66,7 +66,7 @@ public struct KindleBookMetadata: Codable {
 
 /// A struct that parses out books from Kindle JSON API response
 ///
-public struct KindleJSONBook: Decodable {
+public struct KindleJSONBook: Decodable, Sendable {
 
     /*
      Kindle book JSON:


### PR DESCRIPTION
## Summary

This PR unblocks the Scrapes Swift 6 DataLoader refactor.

- bump SwiftSoup to the Swift 6 compatible line
- add explicit sendability annotations to KindleAPI auth and model types
- mark KindleAPI and KindleLoggerProtocol for safe cross-isolation use

## Verification

- swift test

## Notes

This is intended to support the downstream Scrapes branch .
